### PR TITLE
Blocking all the wallets for transfer to fix race condition test

### DIFF
--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -37,6 +37,14 @@ func (r *mutationResolver) Transfer(ctx context.Context, fromAddress string, toA
 	var to_wallet models.Wallet
 	err = tx.Where("address = ?", toAddress).First(&to_wallet).Error
 	if err != nil {
+		to_wallet = models.Wallet{Address: toAddress, Balance: 0}
+		if err := tx.Create(&to_wallet).Error; err != nil {
+			tx.Rollback()
+			return from_wallet.Balance, err
+		}
+	}
+	err = tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("address = ?", toAddress).First(&to_wallet).Error
+	if err != nil {
 		tx.Rollback()
 		return 0, err
 	}

--- a/tests/race_cond_test.go
+++ b/tests/race_cond_test.go
@@ -9,6 +9,8 @@ import (
 	"token-transfer-api/graph"
 	"token-transfer-api/models"
 
+	"fmt"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,21 +21,32 @@ func TestRaceCondition(t *testing.T) {
 	from_address := "0x000from_address"
 	to_address := [3]string{"0x000to_address_1", "0x000to_address_2", "0x000to_address_3"}
 
-	// assert.Error(t, db.DB.Where("address = ?", from_address).First(&models.Wallet{}).Error)
+	assert.Error(t, db.DB.Where("address = ?", from_address).First(&models.Wallet{}).Error)
 	from_wallet := models.Wallet{Address: from_address, Balance: 10}
 	assert.NoError(t, db.DB.Create(&from_wallet).Error)
 	var to_wallet [3]models.Wallet
 	for i := range 3 {
-		// assert.Error(t, db.DB.Where("address = ?", to_address[i]).First(&models.Wallet{}).Error)
+		assert.Error(t, db.DB.Where("address = ?", to_address[i]).First(&models.Wallet{}).Error)
 		to_wallet[i] = models.Wallet{Address: to_address[i], Balance: 10}
 		assert.NoError(t, db.DB.Create(&to_wallet[i]).Error)
 	}
 
+	log.Printf("%s", "Balance before transfers: "+fmt.Sprint(from_wallet.Balance))
+
 	var wg *sync.WaitGroup = new(sync.WaitGroup)
+	var ready *sync.WaitGroup = new(sync.WaitGroup)
+	var start *sync.WaitGroup = new(sync.WaitGroup)
+
 	wg.Add(3)
+	ready.Add(3)
+	start.Add(1)
 
 	go func() {
 		defer wg.Done()
+
+		_ = db.DB.First(&models.Wallet{}, "address = ?", from_address)
+		ready.Done()
+		start.Wait()
 		_, err := resolver.Mutation().Transfer(context.TODO(), to_address[0], from_address, 1)
 		if err == nil {
 			log.Printf("Transfer +1 accepted")
@@ -44,6 +57,10 @@ func TestRaceCondition(t *testing.T) {
 
 	go func() {
 		defer wg.Done()
+
+		_ = db.DB.First(&models.Wallet{}, "address = ?", from_address)
+		ready.Done()
+		start.Wait()
 		_, err := resolver.Mutation().Transfer(context.TODO(), from_address, to_address[1], 4)
 		if err == nil {
 			log.Printf("Transfer -4 accepted")
@@ -54,6 +71,10 @@ func TestRaceCondition(t *testing.T) {
 
 	go func() {
 		defer wg.Done()
+
+		_ = db.DB.First(&models.Wallet{}, "address = ?", from_address)
+		ready.Done()
+		start.Wait()
 		_, err := resolver.Mutation().Transfer(context.TODO(), from_address, to_address[2], 7)
 		if err == nil {
 			log.Printf("Transfer -7 accepted")
@@ -62,16 +83,20 @@ func TestRaceCondition(t *testing.T) {
 		}
 	}()
 
+	ready.Wait()
+	start.Done()
+
 	wg.Wait()
 
 	var updated_from models.Wallet
 	assert.NoError(t, db.DB.First(&updated_from, "address = ?", from_address).Error)
 	assert.True(t, updated_from.Balance >= int32(0))
+	log.Printf("%s", "Balance after transfers: "+fmt.Sprint(updated_from.Balance))
 
 	db.DB.Where("address = ?", from_address).Delete(&models.Wallet{})
-	// assert.Error(t, db.DB.Where("address = ?", from_address).First(&models.Wallet{}).Error)
+	assert.Error(t, db.DB.Where("address = ?", from_address).First(&models.Wallet{}).Error)
 	for i := range 3 {
 		db.DB.Where("address = ?", to_address[i]).Delete(&models.Wallet{})
-		// assert.Error(t, db.DB.Where("address = ?", to_address[i]).First(&models.Wallet{}).Error)
+		assert.Error(t, db.DB.Where("address = ?", to_address[i]).First(&models.Wallet{}).Error)
 	}
 }

--- a/tests/transfer_test.go
+++ b/tests/transfer_test.go
@@ -15,8 +15,8 @@ func TestSuccessfulTransfer(t *testing.T) {
 	from_address := "0xtransfertestfrom123"
 	to_address := "0xtransfertestto321"
 
-	// assert.Error(t, db.DB.Where("address = ?", from_address).First(&models.Wallet{}).Error)
-	// assert.Error(t, db.DB.Where("address = ?", to_address).First(&models.Wallet{}).Error)
+	assert.Error(t, db.DB.Where("address = ?", from_address).First(&models.Wallet{}).Error)
+	assert.Error(t, db.DB.Where("address = ?", to_address).First(&models.Wallet{}).Error)
 
 	from_wallet := models.Wallet{Address: from_address, Balance: 100000}
 	to_wallet := models.Wallet{Address: to_address, Balance: 500}
@@ -40,8 +40,8 @@ func TestSuccessfulTransfer(t *testing.T) {
 	db.DB.Where("address = ?", from_address).Delete(&models.Wallet{})
 	db.DB.Where("address = ?", to_address).Delete(&models.Wallet{})
 
-	// assert.Error(t, db.DB.Where("address = ?", from_address).First(&models.Wallet{}).Error)
-	// assert.Error(t, db.DB.Where("address = ?", to_address).First(&models.Wallet{}).Error)
+	assert.Error(t, db.DB.Where("address = ?", from_address).First(&models.Wallet{}).Error)
+	assert.Error(t, db.DB.Where("address = ?", to_address).First(&models.Wallet{}).Error)
 }
 
 func TestFailedTransfer(t *testing.T) {
@@ -51,11 +51,11 @@ func TestFailedTransfer(t *testing.T) {
 	resolver := &graph.Resolver{}
 	var err error
 
+	assert.Error(t, db.DB.Where("address = ?", from_address).First(&models.Wallet{}).Error)
+	assert.Error(t, db.DB.Where("address = ?", to_address).First(&models.Wallet{}).Error)
+
 	_, err = resolver.Mutation().Transfer(context.TODO(), from_address, to_address, 7)
 	assert.Error(t, err)
-
-	// assert.Error(t, db.DB.Where("address = ?", from_address).First(&models.Wallet{}).Error)
-	// assert.Error(t, db.DB.Where("address = ?", to_address).First(&models.Wallet{}).Error)
 
 	from_wallet := models.Wallet{Address: from_address, Balance: 10}
 	to_wallet := models.Wallet{Address: to_address, Balance: 500}
@@ -80,6 +80,6 @@ func TestFailedTransfer(t *testing.T) {
 	db.DB.Where("address = ?", from_address).Delete(&models.Wallet{})
 	db.DB.Where("address = ?", to_address).Delete(&models.Wallet{})
 
-	// assert.Error(t, db.DB.Where("address = ?", from_address).First(&models.Wallet{}).Error)
-	// assert.Error(t, db.DB.Where("address = ?", to_address).First(&models.Wallet{}).Error)
+	assert.Error(t, db.DB.Where("address = ?", from_address).First(&models.Wallet{}).Error)
+	assert.Error(t, db.DB.Where("address = ?", to_address).First(&models.Wallet{}).Error)
 }


### PR DESCRIPTION
schema.resolvers.go has been modified so that it blocks all the wallets used for transfer, not only fromAddress wallet. Race condition test now ensures that write operations in both threads do not begin until the preconditions.